### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/AllenDang/color_reducer/compare/v0.1.1...v0.1.2) - 2024-12-11
+
+### Other
+
+- Use KdTree to match with palette
+
 ## [0.1.1](https://github.com/AllenDang/color_reducer/compare/v0.1.0...v0.1.1) - 2024-12-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "color_reducer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "image",
  "kd-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color_reducer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Simplify images by reducing the number of colors based on a predefined palette."
 categories = ["multimedia", "multimedia::images"]


### PR DESCRIPTION
## 🤖 New release
* `color_reducer`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/AllenDang/color_reducer/compare/v0.1.1...v0.1.2) - 2024-12-11

### Other

- Use KdTree to match with palette
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).