### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/AllenDang/color_reducer/compare/v0.1.2...v0.1.3) - 2024-12-11
+
+### Other
+
+- Bump to 0.1.3
+- Revert KdTree use palette matching
+
 ## [0.1.2](https://github.com/AllenDang/color_reducer/compare/v0.1.1...v0.1.2) - 2024-12-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "color_reducer"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "image",
  "palette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color_reducer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Simplify images by reducing the number of colors based on a predefined palette."
 categories = ["multimedia", "multimedia::images"]


### PR DESCRIPTION
## 🤖 New release
* `color_reducer`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/AllenDang/color_reducer/compare/v0.1.2...v0.1.3) - 2024-12-11

### Other

- Bump to 0.1.3
- Revert KdTree use palette matching
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).