### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/AllenDang/color_reducer/compare/v0.2.0...v0.3.0) - 2024-12-11
+
+### Other
+
+- Use media filter instead of merge pixel area
+
 ## [0.2.0](https://github.com/AllenDang/color_reducer/compare/v0.1.3...v0.2.0) - 2024-12-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "color_reducer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "image",
  "imageproc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color_reducer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Simplify images by reducing the number of colors based on a predefined palette."
 categories = ["multimedia", "multimedia::images"]


### PR DESCRIPTION
## 🤖 New release
* `color_reducer`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `color_reducer` breaking changes

```
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  color_reducer::prelude::ColorReducer::reduce now takes 2 parameters instead of 3, in /tmp/.tmpSW1CaJ/color_reducer/src/color_reducer.rs:18
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/AllenDang/color_reducer/compare/v0.2.0...v0.3.0) - 2024-12-11

### Other

- Use media filter instead of merge pixel area
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).